### PR TITLE
Fix Wire I2C restart handling (#586)

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -126,7 +126,7 @@ void TwoWire::begin(uint8_t addr) {
     i2c_set_slave_mode(_i2c, true, addr);
 
     // Our callback IRQ
-    _i2c->hw->intr_mask = (1 << 10) | (1 << 9) | (1 << 6) | (1 << 5) | (1 << 2);
+    _i2c->hw->intr_mask = (1 << 12) | (1 << 10) | (1 << 9) | (1 << 6) | (1 << 5) | (1 << 2);
 
     int irqNo = I2C0_IRQ + i2c_hw_index(_i2c);
     irq_set_exclusive_handler(irqNo, i2c_hw_index(_i2c) == 0 ? _handler0 : _handler1);
@@ -142,6 +142,15 @@ void TwoWire::begin(uint8_t addr) {
 }
 
 void TwoWire::onIRQ() {
+    if (_i2c->hw->intr_stat & (1 << 12)) {
+        if (_onReceiveCallback && _buffLen) {
+            _onReceiveCallback(_buffLen);
+        }
+        _buffLen = 0;
+        _buffOff = 0;
+        _slaveStartDet = false;
+        _i2c->hw->clr_restart_det;
+    }
     if (_i2c->hw->intr_stat & (1 << 10)) {
         _buffLen = 0;
         _buffOff = 0;


### PR DESCRIPTION
Fixes #585

On an I2C bus restart, call the onReceive callback and clear the buffer.

Thanks to @DWiskow for the debug and patch!